### PR TITLE
allow human readable key name: get_storage_by_key(storage_key_name)

### DIFF
--- a/simpletest.py
+++ b/simpletest.py
@@ -1,0 +1,33 @@
+import substrateinterface
+
+RPC_URL = "https://dev-node.substrate.dev:9933/"
+SI = substrateinterface.SubstrateInterface(url=RPC_URL)
+
+block_hash = SI.get_chain_head()
+print (block_hash, " = block hash of chain head")
+
+storage_key_name = "Sudo Key"
+storage_key = substrateinterface.xxh6464(storage_key_name)
+
+r1 = SI.get_storage_by_key(storage_key=storage_key, block_hash=block_hash)
+print (r1, " = get_storage_by_key(storage_key=%s)" % storage_key)
+
+r2 = SI.get_storage_by_key(storage_key_name=storage_key_name, block_hash=block_hash)
+print (r2, " = get_storage_by_key(storage_key_name='%s')" % storage_key_name)
+
+print("both None: ", end=" ")
+try:
+    SI.get_storage_by_key(block_hash=block_hash)
+except Exception as e:
+    print (type(e), e)
+
+print("both given:", end=" ")
+try:
+    SI.get_storage_by_key(storage_key_name=storage_key_name, storage_key=storage_key, block_hash=block_hash)
+except Exception as e:
+    print (type(e), e)
+
+storage_key_name = "what if this is much longer and 2 times 64 bits are not enough?"
+storage_key = substrateinterface.xxh6464(storage_key_name)
+r3 = SI.get_storage_by_key(storage_key_name=storage_key_name, block_hash=block_hash)
+print (r3, " = get_storage_by_key(storage_key_name='%s')" % storage_key_name)

--- a/substrateinterface/__init__.py
+++ b/substrateinterface/__init__.py
@@ -30,6 +30,14 @@ from .exceptions import SubstrateRequestException
 from .constants import *
 
 
+def xxh6464(x):
+    o1 = bytearray(xxhash.xxh64(x, seed=0).digest())
+    o1.reverse()
+    o2 = bytearray(xxhash.xxh64(x, seed=1).digest())
+    o2.reverse()
+    return "0x{}{}".format(o1.hex(), o2.hex())
+    
+
 class SubstrateInterface:
 
     def __init__(self, url, metadata_version=4):
@@ -174,7 +182,11 @@ class SubstrateInterface:
         else:
             raise SubstrateRequestException("Error occurred during retrieval of events")
 
-    def get_storage_by_key(self, block_hash, storage_key):
+    def get_storage_by_key(self, block_hash, storage_key=None, storage_key_name=None):
+        if (not storage_key and not storage_key_name) or (storage_key and storage_key_name):
+            raise SubstrateRequestException("Must give EITHER storage_key OR storage_key_name")
+        if not storage_key:
+            storage_key = xxh6464(storage_key_name)
 
         response = self.rpc_request("state_getStorageAt", [storage_key, block_hash])
         if 'result' in response:


### PR DESCRIPTION
allows 

    get_storage_by_key(storage_key_name='Sudo Key')

not only 

    get_storage_by_key(storage_key=0x50a63a871aced22e88ee6466fe5aa5d9)

See https://github.com/ifduyue/python-xxhash/issues/34#issuecomment-555929173 and https://github.com/polkascan/py-substrate-interface/issues/3#issue-526238720 (<-- with that please help me! Thanks.)

Included is a `python simpletest.py` but you probably don't want to merge that.