### PR TITLE
Remove asyncio from pip requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,6 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'asyncio>=3.4.3',
         'websockets>=8.1',
         'base58>=2.0.1',
         'certifi>=2019.6.16',


### PR DESCRIPTION
asyncio is part of the python stdlib. This prevents the in built version being overridden by an older version which can cause issues. e.g. on AWS lambda and google cloud function.