### PR TITLE
fixing calculation of total fee amount when event is a balances/deposit

### DIFF
--- a/substrateinterface/base.py
+++ b/substrateinterface/base.py
@@ -2963,7 +2963,7 @@ class ExtrinsicReceipt:
                         self.__total_fee_amount += event.value['attributes']
 
                     elif event.value['module_id'] == 'Balances' and event.value['event_id'] == 'Deposit':
-                        self.__total_fee_amount += event.value['attributes']
+                        self.__total_fee_amount += event.value['attributes'][1]
                 else:
 
                     if event.event_module.name == 'System' and event.event.name == 'ExtrinsicSuccess':


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
In `ExtrinsicReceipt.process_events()`, for Balances/Deposit event, `event.value["attributes"]` is a tuple. Currently it's giving a `ValueError("unsupported operand type(s) for +=: 'int' and 'tuple'")` because code is trying to add an integer and a tuple.

**How did you solve this problem?**
By using the fee value inside of the tuple instead of the tuple.

**How did you make sure your solution works?**
It calculates total fee correctly without `ValueError`

**Are there any special changes in the code that we should be aware of?**
no