### PR TITLE
Implemented well-known storage keys in query()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ eth-keys>=0.2.1,<1
 eth_utils>=1.3.0,<3
 pycryptodome>=3.11.0,<4
 
-scalecodec>=1.0.32,<2
+scalecodec>=1.0.33,<2
 py-sr25519-bindings>=0.1.2,<1
 py-ed25519-bindings>=1.0,<2
 py-bip39-bindings>=0.1.8,<1

--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,7 @@ setup(
         'eth-keys>=0.2.1,<1',
         'eth_utils>=1.3.0,<3',
         'pycryptodome>=3.11.0,<4',
-        'scalecodec>=1.0.32,<2',
+        'scalecodec>=1.0.33,<2',
         'py-sr25519-bindings>=0.1.2,<1',
         'py-ed25519-bindings>=1.0,<2',
         'py-bip39-bindings>=0.1.8,<1'

--- a/substrateinterface/constants.py
+++ b/substrateinterface/constants.py
@@ -18,3 +18,24 @@ STORAGE_HASH_SYSTEM_EVENTS = "0xcc956bdb7605e3547539f321ac2bc95c"
 STORAGE_HASH_SYSTEM_EVENTS_V9 = "0x26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7"
 
 DEV_PHRASE = 'bottom drive obey lake curtain smoke basket hold race lonely fit walk'
+
+WELL_KNOWN_STORAGE_KEYS = {
+    "Code": {
+        "storage_key": "0x3a636f6465",
+        "value_type_string": "RawBytes",
+        "docs": "Wasm code of the runtime",
+        "default": None
+    },
+    "HeapPages": {
+        "storage_key": "0x3a686561707061676573",
+        "value_type_string": "u64",
+        "docs": "Number of wasm linear memory pages required for execution of the runtime.",
+        "default": "0x0000000000000000"
+    },
+    "ExtrinsicIndex": {
+        "storage_key": "0x3a65787472696e7369635f696e646578",
+        "value_type_string": "u32",
+        "docs": "Number of wasm linear memory pages required for execution of the runtime.",
+        "default": "0x00000000"
+    },
+}

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -18,6 +18,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from substrateinterface import SubstrateInterface
+from substrateinterface.exceptions import StorageFunctionNotFound
 from test import settings
 
 
@@ -66,7 +67,7 @@ class QueryTestCase(unittest.TestCase):
             }, result.value)
 
     def test_non_existing_query(self):
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(StorageFunctionNotFound) as cm:
             self.kusama_substrate.query("Unknown", "StorageFunction")
 
         self.assertEqual('Storage function "Unknown.StorageFunction" not found', str(cm.exception))
@@ -96,6 +97,18 @@ class QueryTestCase(unittest.TestCase):
     def test_identity_hasher(self):
         result = self.kusama_substrate.query("Claims", "Claims", ["0x00000a9c44f24e314127af63ae55b864a28d7aee"])
         self.assertEqual(45880000000000, result.value)
+
+    def test_well_known_keys_result(self):
+        result = self.kusama_substrate.query("Substrate", "Code")
+        self.assertIsNotNone(result.value)
+
+    def test_well_known_keys_default(self):
+        result = self.kusama_substrate.query("Substrate", "HeapPages")
+        self.assertEqual(0, result.value)
+
+    def test_well_known_keys_not_found(self):
+        with self.assertRaises(StorageFunctionNotFound):
+            self.kusama_substrate.query("Substrate", "Unknown")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implement 'well-known' storage keys described in Substrate:

https://github.com/paritytech/substrate/blob/ded44948e2d5a398abcb4e342b0513cb690961bb/primitives/storage/src/lib.rs#L192-L238

And make expose them in the same manner PolkadotJS does: https://github.com/polkadot-js/api/blob/8ba4ed53776a7a71478e229547c7af3d4dc57d63/packages/types/src/metadata/decorate/storage/substrate.ts

Closes #190