### PR TITLE
Reuse TCP connection for HTTP requests

### DIFF
--- a/substrateinterface/base.py
+++ b/substrateinterface/base.py
@@ -476,6 +476,8 @@ class SubstrateInterface:
             'auto_discover': auto_discover
         }
 
+        self.session = requests.Session()
+
         self.reload_type_registry(use_remote_preset=use_remote_preset, auto_discover=auto_discover)
 
     def connect_websocket(self):
@@ -595,7 +597,7 @@ class SubstrateInterface:
             if result_handler:
                 raise ConfigurationError("Result handlers only available for websockets (ws://) connections")
 
-            response = requests.request("POST", self.url, data=json.dumps(payload), headers=self.default_headers)
+            response = self.session.request("POST", self.url, data=json.dumps(payload), headers=self.default_headers)
 
             if response.status_code != 200:
                 raise SubstrateRequestException(


### PR DESCRIPTION
Currently, when making an HTTP request we use the `requests.request` method. This creates a new TCP connection for each request, and can lead to port exhaustion if you're performing many requests.

This PR adds a persistent [Session](https://docs.python-requests.org/en/latest/user/advanced/#session-objects) for HTTP requests so that TCP connections are reused when possible. This avoids port exhaustion and improves performance for HTTP requests.

Fixes #18.