### PR TITLE
Fix rpc message order

### DIFF
--- a/substrateinterface/base.py
+++ b/substrateinterface/base.py
@@ -55,6 +55,22 @@ __all__ = ['Keypair', 'KeypairType', 'SubstrateInterface', 'ExtrinsicReceipt', '
 logger = logging.getLogger(__name__)
 
 
+def list_remove_iter(xs: list):
+    removed = False
+    def remove():
+        nonlocal removed
+        removed = True
+
+    i = 0
+    while i < len(xs):
+        removed = False
+        yield xs[i], remove
+        if removed:
+            xs.pop(i)
+        else:
+            i += 1
+
+
 class KeypairType:
     ED25519 = 0
     SR25519 = 1
@@ -744,12 +760,12 @@ class SubstrateInterface:
 
             while json_body is None:
                 # Search for subscriptions
-                for message in self.__rpc_message_queue:
+                for message, remove_message in list_remove_iter(self.__rpc_message_queue):
 
                     # Check if result message is matching request ID
                     if 'id' in message and message['id'] == request_id:
 
-                        self.__rpc_message_queue.remove(message)
+                        remove_message()
 
                         # Check if response has error
                         if 'error' in message:
@@ -766,11 +782,11 @@ class SubstrateInterface:
                             json_body = message
 
                 # Process subscription updates
-                for message in self.__rpc_message_queue:
+                for message, remove_message in list_remove_iter(self.__rpc_message_queue):
                     # Check if message is meant for this subscription
                     if 'params' in message and message['params']['subscription'] == subscription_id:
 
-                        self.__rpc_message_queue.remove(message)
+                        remove_message()
 
                         self.debug_message(f"Websocket result [{subscription_id} #{update_nr}]: {message}")
 

--- a/substrateinterface/base.py
+++ b/substrateinterface/base.py
@@ -743,9 +743,6 @@ class SubstrateInterface:
             subscription_id = None
 
             while json_body is None:
-
-                self.__rpc_message_queue.append(json.loads(self.websocket.recv()))
-
                 # Search for subscriptions
                 for message in self.__rpc_message_queue:
 
@@ -783,6 +780,10 @@ class SubstrateInterface:
                             json_body = callback_result
 
                         update_nr += 1
+
+                # Read one more message to queue
+                if json_body is None:
+                    self.__rpc_message_queue.append(json.loads(self.websocket.recv()))
 
         else:
 


### PR DESCRIPTION
Looks like original code expected subscription events to arrive earlier than subscription id, e.g.:
```
{subscription: 1, result: ...}
{subscription: 1}
{subscription: 1, result: ...}
```
But there were two problems:
1. removing processed messages was skipping some messages
2. always reading before checking queued messages delayed those messages processing