### PR TITLE
Keypair: set ss58_format default to 42

### DIFF
--- a/substrateinterface/base.py
+++ b/substrateinterface/base.py
@@ -75,7 +75,7 @@ class MnemonicLanguageCode:
 class Keypair:
 
     def __init__(self, ss58_address: str = None, public_key: Union[bytes, str] = None,
-                 private_key: Union[bytes, str] = None, ss58_format: int = None, seed_hex: Union[str, bytes] = None,
+                 private_key: Union[bytes, str] = None, ss58_format: int = 42, seed_hex: Union[str, bytes] = None,
                  crypto_type: int = KeypairType.SR25519):
         """
         Allows generation of Keypairs from a variety of input combination, such as a public/private key combination,

--- a/test/test_create_extrinsics.py
+++ b/test/test_create_extrinsics.py
@@ -168,7 +168,7 @@ class CreateExtrinsicsTestCase(unittest.TestCase):
         self.assertEqual(str(extrinsic.data), '0x280402000ba09cc0317501')
 
     def test_payment_info(self):
-        keypair = Keypair(ss58_address="EaG2CRhJWPb7qmdcJvy3LiWdh26Jreu9Dx6R1rXxPmYXoDk")
+        keypair = Keypair(ss58_address="EaG2CRhJWPb7qmdcJvy3LiWdh26Jreu9Dx6R1rXxPmYXoDk", ss58_format=2)
 
         call = self.kusama_substrate.compose_call(
             call_module='Balances',

--- a/test/test_keypair.py
+++ b/test/test_keypair.py
@@ -66,7 +66,7 @@ class KeyPairTestCase(unittest.TestCase):
 
     def test_only_provide_ss58_address(self):
 
-        keypair = Keypair(ss58_address='16ADqpMa4yzfmWs3nuTSMhfZ2ckeGtvqhPWCNqECEGDcGgU2')
+        keypair = Keypair(ss58_address='16ADqpMa4yzfmWs3nuTSMhfZ2ckeGtvqhPWCNqECEGDcGgU2', ss58_format=0)
         self.assertEqual(keypair.public_key, bytes.fromhex('e4359ad3e2716c539a1d663ebd0a51bdc5c98a12e663bb4c4402db47828c9446'))
 
     def test_only_provide_public_key(self):


### PR DESCRIPTION
as mentioned in [the documentation](https://polkascan.github.io/py-substrate-interface/#substrateinterface.Keypair)
42 `ss58_format` is for test currencies

Fix tests by providing expected `ss58_format`.