### PR TITLE
Custom ss58_format for ss58_encode()

### DIFF
--- a/substrateinterface/base.py
+++ b/substrateinterface/base.py
@@ -2985,19 +2985,26 @@ class SubstrateInterface:
         )
         return obj.encode(value)
 
-    def ss58_encode(self, public_key: Union[str, bytes]) -> str:
+    def ss58_encode(self, public_key: Union[str, bytes], ss58_format: int = None) -> str:
         """
-        Helper function to encode a public key to SS58 address
+        Helper function to encode a public key to SS58 address.
+
+        If no target `ss58_format` is provided, it will default to the ss58 format of the network it's connected to.
 
         Parameters
         ----------
-        public_key
+        public_key: 32 bytes or hex-string. e.g. 0x6e39f36c370dd51d9a7594846914035de7ea8de466778ea4be6c036df8151f29
+        ss58_format: target networkID to format the address for, defaults to the network it's connected to
 
         Returns
         -------
         str containing the SS58 address
         """
-        return ss58_encode(public_key, ss58_format=self.ss58_format)
+
+        if ss58_format is None:
+            ss58_format = self.ss58_format
+
+        return ss58_encode(public_key, ss58_format=ss58_format)
 
     def ss58_decode(self, ss58_address: str) -> str:
         """

--- a/test/test_helper_functions.py
+++ b/test/test_helper_functions.py
@@ -21,7 +21,7 @@ from scalecodec import GenericExtrinsic
 from scalecodec.type_registry import load_type_registry_file, load_type_registry_preset
 from substrateinterface.exceptions import SubstrateRequestException
 from scalecodec.base import ScaleBytes
-from substrateinterface import SubstrateInterface
+from substrateinterface import SubstrateInterface, Keypair
 from test.settings import POLKADOT_NODE_URL
 
 
@@ -301,6 +301,39 @@ class TestRPCHelperFunctions(unittest.TestCase):
         self.assertEqual(len(pending_extrinsics), 2)
         self.assertIsInstance(pending_extrinsics[0], GenericExtrinsic)
         self.assertIsInstance(pending_extrinsics[1], GenericExtrinsic)
+
+
+class SS58HelperTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.keypair = Keypair.create_from_uri('//Alice')
+
+        cls.substrate = SubstrateInterface(url=POLKADOT_NODE_URL)
+
+    def test_ss58_decode(self):
+
+        public_key = self.substrate.ss58_decode("15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5")
+
+        self.assertEqual("d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d", public_key)
+
+    def test_ss58_encode(self):
+        ss58_address = self.substrate.ss58_encode("d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d")
+        self.assertEqual("15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5", ss58_address)
+
+        ss58_address = self.substrate.ss58_encode("0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d")
+        self.assertEqual("15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5", ss58_address)
+
+        ss58_address = self.substrate.ss58_encode(
+            bytes.fromhex("d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d")
+        )
+        self.assertEqual("15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5", ss58_address)
+
+    def test_ss58_encode_custom_format(self):
+        ss58_address = self.substrate.ss58_encode(
+            "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d", ss58_format=2
+        )
+        self.assertEqual("HNZata7iMYWmk5RvZRTiAsSDhV8366zq2YGb3tLH5Upf74F", ss58_address)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently, the function always encodes to `ss58_format` of connected network. A way to override this is desired.