### PR TITLE
Add method to subscribe to multiple storage keys at once

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -307,3 +307,30 @@ result = substrate.query("System", "Account", ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHp
 
 print(result)
 ```
+
+## Subscribe to multiple storage keys 
+
+```python
+from substrateinterface import SubstrateInterface
+
+
+def subscription_handler(storage_key, updated_obj, update_nr, subscription_id):
+    print(f"Update for {storage_key.params[0]}: {updated_obj.value}")
+
+
+substrate = SubstrateInterface(url="ws://127.0.0.1:9944")
+
+# Accounts to track
+storage_keys = [
+    substrate.create_storage_key(
+        "System", "Account", ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"]
+    ),
+    substrate.create_storage_key(
+        "System", "Account", ["5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"]
+    )
+]
+
+result = substrate.subscribe_storage(
+    storage_keys=storage_keys, subscription_handler=subscription_handler
+)
+```

--- a/docs/reference/storage.md
+++ b/docs/reference/storage.md
@@ -1,0 +1,1 @@
+::: substrateinterface.storage

--- a/docs/usage/subscriptions.md
+++ b/docs/usage/subscriptions.md
@@ -31,6 +31,34 @@ result = substrate.query("System", "Account", ["5GNJqTPyNqANBkUVMN1LPPrxXnFouWXo
 print(result)
 ```
 
+## Subscribe to multiple storage keys 
+
+To subscribe to multiple storage keys at once, the function `subscribe_storage()` provides the most efficient method.
+This will track changes for multiple state entries (storage keys) in just one RPC call to the Substrate node.
+
+Same as for `query()`, updates will be pushed to the `subscription_handler` callable and will block execution until 
+a final value is returned. This value will be returned as a result of subscription and finally automatically
+unsubscribed from further updates.
+
+```python
+def subscription_handler(storage_key, updated_obj, update_nr, subscription_id):
+    print(f"Update for {storage_key.params[0]}: {updated_obj.value}")
+
+# Accounts to track
+storage_keys = [
+    substrate.create_storage_key(
+        "System", "Account", ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"]
+    ),
+    substrate.create_storage_key(
+        "System", "Account", ["5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"]
+    )
+]
+
+result = substrate.subscribe_storage(
+    storage_keys=storage_keys, subscription_handler=subscription_handler
+)
+```
+
 ## Subscribe to new block headers
 
 ```python

--- a/examples/storage_subscription.py
+++ b/examples/storage_subscription.py
@@ -1,0 +1,37 @@
+# Python Substrate Interface Library
+#
+# Copyright 2018-2023 Stichting Polkascan (Polkascan Foundation).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from substrateinterface import SubstrateInterface
+
+
+def subscription_handler(storage_key, updated_obj, update_nr, subscription_id):
+    print(f"Update for {storage_key.params[0]}: {updated_obj.value}")
+
+
+substrate = SubstrateInterface(url="ws://127.0.0.1:9944")
+
+# Accounts to track
+storage_keys = [
+    substrate.create_storage_key(
+        "System", "Account", ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"]
+    ),
+    substrate.create_storage_key(
+        "System", "Account", ["5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"]
+    )
+]
+
+result = substrate.subscribe_storage(
+    storage_keys=storage_keys, subscription_handler=subscription_handler
+)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,15 +62,16 @@ nav:
   - Usage:
     - usage/query-storage.md
     - usage/using-scaletype-objects.md
+    - usage/subscriptions.md
     - usage/call-runtime-apis.md
     - usage/keypair-creation-and-signing.md
     - usage/creating-extrinsics.md
     - usage/ink-contract-interfacing.md
-    - usage/subscriptions.md
     - usage/cleanup-and-context-manager.md
   - Function Reference:
     - reference/base.md
     - reference/contracts.md
+    - reference/storage.md
   - Examples: examples.md
   - Metadata docs: https://polkascan.github.io/py-substrate-metadata-docs/
 

--- a/substrateinterface/storage.py
+++ b/substrateinterface/storage.py
@@ -1,0 +1,231 @@
+# Python Substrate Interface Library
+#
+# Copyright 2018-2023 Stichting Polkascan (Polkascan Foundation).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import binascii
+from typing import Any
+
+from substrateinterface.exceptions import StorageFunctionNotFound
+
+from scalecodec import ScaleBytes, GenericMetadataVersioned, ss58_decode
+from scalecodec.base import ScaleDecoder, RuntimeConfigurationObject
+from .utils.hasher import blake2_256, two_x64_concat, xxh128, blake2_128, blake2_128_concat, identity
+
+
+class StorageKey:
+    """
+    A StorageKey instance is a representation of a single state entry.
+
+    Substrate uses a simple key-value data store implemented as a database-backed, modified Merkle tree.
+    All of Substrate's higher-level storage abstractions are built on top of this simple key-value store.
+    """
+
+    def __init__(
+            self, pallet: str, storage_function: str, params: list,
+            data: bytes, value_scale_type: str, metadata: GenericMetadataVersioned,
+            runtime_config: RuntimeConfigurationObject
+    ):
+        self.pallet = pallet
+        self.storage_function = storage_function
+        self.params = params
+        self.params_encoded = []
+        self.data = data
+        self.metadata = metadata
+        self.runtime_config = runtime_config
+        self.value_scale_type = value_scale_type
+        self.metadata_storage_function = None
+
+    @classmethod
+    def create_from_data(cls, data: bytes, runtime_config: RuntimeConfigurationObject,
+                         metadata: GenericMetadataVersioned, value_scale_type: str = None, pallet: str = None,
+                         storage_function: str = None) -> 'StorageKey':
+        """
+        Create a StorageKey instance providing raw storage key bytes
+
+        Parameters
+        ----------
+        data: bytes representation of the storage key
+        runtime_config: RuntimeConfigurationObject
+        metadata: GenericMetadataVersioned
+        value_scale_type: type string of to decode result data
+        pallet: name of pallet
+        storage_function: name of storage function
+
+        Returns
+        -------
+        StorageKey
+        """
+        if not value_scale_type and pallet and storage_function:
+            metadata_pallet = metadata.get_metadata_pallet(pallet)
+
+            if not metadata_pallet:
+                raise StorageFunctionNotFound(f'Pallet "{pallet}" not found')
+
+            storage_item = metadata_pallet.get_storage_function(storage_function)
+
+            if not storage_item:
+                raise StorageFunctionNotFound(f'Storage function "{pallet}.{storage_function}" not found')
+
+            # Process specific type of storage function
+            value_scale_type = storage_item.get_value_type_string()
+
+        return cls(
+            pallet=None, storage_function=None, params=None,
+            data=data, metadata=metadata,
+            value_scale_type=value_scale_type, runtime_config=runtime_config
+        )
+
+    @classmethod
+    def create_from_storage_function(cls, pallet: str, storage_function: str, params: list,
+                                     runtime_config: RuntimeConfigurationObject,
+                                     metadata: GenericMetadataVersioned) -> 'StorageKey':
+        """
+        Create a StorageKey instance providing storage function details
+
+        Parameters
+        ----------
+        pallet: name of pallet
+        storage_function: name of storage function
+        params: Optional list of parameters in case of a Mapped storage function
+        runtime_config: RuntimeConfigurationObject
+        metadata: GenericMetadataVersioned
+
+        Returns
+        -------
+        StorageKey
+        """
+        storage_key_obj = cls(
+            pallet=pallet, storage_function=storage_function, params=params,
+            data=None, runtime_config=runtime_config, metadata=metadata, value_scale_type=None
+        )
+
+        storage_key_obj.generate()
+
+        return storage_key_obj
+
+    def convert_storage_parameter(self, scale_type: str, value: Any):
+
+        if type(value) is bytes:
+            value = f'0x{value.hex()}'
+
+        if scale_type == 'AccountId':
+            if value[0:2] != '0x':
+                return '0x{}'.format(ss58_decode(value, self.runtime_config.ss58_format))
+
+        return value
+
+    def to_hex(self) -> str:
+        """
+        Returns a Hex-string representation of current StorageKey data
+
+        Returns
+        -------
+        str Hex string
+        """
+        if self.data:
+            return f'0x{self.data.hex()}'
+
+    def generate(self) -> bytes:
+        """
+        Generate a storage key for current specified pallet/function/params
+
+        Returns
+        -------
+        bytes
+        """
+
+        # Search storage call in metadata
+        metadata_pallet = self.metadata.get_metadata_pallet(self.pallet)
+
+        if not metadata_pallet:
+            raise StorageFunctionNotFound(f'Pallet "{self.pallet}" not found')
+
+        self.metadata_storage_function = metadata_pallet.get_storage_function(self.storage_function)
+
+        if not self.metadata_storage_function:
+            raise StorageFunctionNotFound(f'Storage function "{self.pallet}.{self.storage_function}" not found')
+
+        # Process specific type of storage function
+        self.value_scale_type = self.metadata_storage_function.get_value_type_string()
+        param_types = self.metadata_storage_function.get_params_type_string()
+
+        hashers = self.metadata_storage_function.get_param_hashers()
+
+        # Encode parameters
+        self.params_encoded = []
+        for idx, param in enumerate(self.params):
+            if type(param) is ScaleBytes:
+                # Already encoded
+                self.params_encoded.append(param)
+            else:
+                param = self.convert_storage_parameter(param_types[idx], param)
+                param_obj = self.runtime_config.create_scale_object(type_string=param_types[idx])
+                self.params_encoded.append(param_obj.encode(param))
+
+        storage_hash = xxh128(metadata_pallet.value['storage']['prefix'].encode()) + xxh128(self.storage_function.encode())
+
+        if self.params_encoded:
+
+            for idx, param in enumerate(self.params_encoded):
+                # Get hasher assiociated with param
+                try:
+                    param_hasher = hashers[idx]
+                except IndexError:
+                    raise ValueError(f'No hasher found for param #{idx + 1}')
+
+                params_key = bytes()
+
+                # Convert param to bytes
+                if type(param) is str:
+                    params_key += binascii.unhexlify(param)
+                elif type(param) is ScaleBytes:
+                    params_key += param.data
+                elif isinstance(param, ScaleDecoder):
+                    params_key += param.data.data
+
+                if not param_hasher:
+                    param_hasher = 'Twox128'
+
+                if param_hasher == 'Blake2_256':
+                    storage_hash += blake2_256(params_key)
+
+                elif param_hasher == 'Blake2_128':
+                    storage_hash += blake2_128(params_key)
+
+                elif param_hasher == 'Blake2_128Concat':
+                    storage_hash += blake2_128_concat(params_key)
+
+                elif param_hasher == 'Twox128':
+                    storage_hash += xxh128(params_key)
+
+                elif param_hasher == 'Twox64Concat':
+                    storage_hash += two_x64_concat(params_key)
+
+                elif param_hasher == 'Identity':
+                    storage_hash += identity(params_key)
+
+                else:
+                    raise ValueError('Unknown storage hasher "{}"'.format(param_hasher))
+
+        self.data = storage_hash
+
+        return self.data
+
+    def __repr__(self):
+        if self.pallet and self.storage_function:
+            return f'<StorageKey(pallet={self.pallet}, storage_function={self.storage_function}, params={self.params})>'
+        elif self.data:
+            return f'<StorageKey(data=0x{self.data.hex()})>'
+        else:
+            return repr(self)

--- a/substrateinterface/utils/encrypted_json.py
+++ b/substrateinterface/utils/encrypted_json.py
@@ -2,7 +2,7 @@ import base64
 import json
 from os import urandom
 
-from typing import Union, Optional
+from typing import Union
 
 from nacl.hashlib import scrypt
 from nacl.secret import SecretBox
@@ -121,7 +121,6 @@ def encode_pair(public_key: bytes, private_key: bytes, passphrase: str) -> bytes
     (Encrypted) PKCS#8 message bytes
     """
     message = encode_pkcs8(public_key, private_key)
-
 
     salt = urandom(SALT_LENGTH)
     password = scrypt(passphrase.encode(), salt, n=SCRYPT_N, r=SCRYPT_R, p=SCRYPT_P, dklen=32, maxmem=2 ** 26)

--- a/substrateinterface/utils/hasher.py
+++ b/substrateinterface/utils/hasher.py
@@ -33,7 +33,7 @@ def blake2_256(data):
     -------
 
     """
-    return blake2b(data, digest_size=32).digest().hex()
+    return blake2b(data, digest_size=32).digest()
 
 
 def blake2_128(data):
@@ -48,7 +48,7 @@ def blake2_128(data):
     -------
 
     """
-    return blake2b(data, digest_size=16).digest().hex()
+    return blake2b(data, digest_size=16).digest()
 
 
 def blake2_128_concat(data):
@@ -64,7 +64,7 @@ def blake2_128_concat(data):
     -------
 
     """
-    return "{}{}".format(blake2b(data, digest_size=16).digest().hex(), data.hex())
+    return blake2b(data, digest_size=16).digest() + data
 
 
 def xxh128(data):
@@ -85,7 +85,7 @@ def xxh128(data):
     storage_key2 = bytearray(xxhash.xxh64(data, seed=1).digest())
     storage_key2.reverse()
 
-    return "{}{}".format(storage_key1.hex(), storage_key2.hex())
+    return storage_key1 + storage_key2
 
 
 def two_x64_concat(data):
@@ -104,15 +104,15 @@ def two_x64_concat(data):
     storage_key = bytearray(xxhash.xxh64(data, seed=0).digest())
     storage_key.reverse()
 
-    return "{}{}".format(storage_key.hex(), data.hex())
+    return storage_key + data
 
 
 def xxh64(data):
     storage_key = bytearray(xxhash.xxh64(data, seed=0).digest())
     storage_key.reverse()
 
-    return "{}".format(storage_key.hex())
+    return storage_key
 
 
 def identity(data):
-    return data.hex()
+    return data

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -70,7 +70,11 @@ class QueryTestCase(unittest.TestCase):
         with self.assertRaises(StorageFunctionNotFound) as cm:
             self.kusama_substrate.query("Unknown", "StorageFunction")
 
-        self.assertEqual('Storage function "Unknown.StorageFunction" not found', str(cm.exception))
+        self.assertEqual('Pallet "Unknown" not found', str(cm.exception))
+
+    def test_missing_params(self):
+        with self.assertRaises(ValueError) as cm:
+            self.kusama_substrate.query("System", "Account")
 
     def test_modifier_default_result(self):
         result = self.kusama_substrate.query(

--- a/test/test_query_map.py
+++ b/test/test_query_map.py
@@ -155,7 +155,7 @@ class QueryMapTestCase(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             self.kusama_substrate.query_map("Unknown", "StorageFunction")
 
-        self.assertEqual('Storage function "Unknown.StorageFunction" not found', str(cm.exception))
+        self.assertEqual('Pallet "Unknown" not found', str(cm.exception))
 
     def test_non_map_function_query_map(self):
         with self.assertRaises(ValueError) as cm:

--- a/test/test_subscriptions.py
+++ b/test/test_subscriptions.py
@@ -25,7 +25,8 @@ class SubscriptionsTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.substrate = SubstrateInterface(
-            url=settings.POLKADOT_NODE_URL
+            # url=settings.POLKADOT_NODE_URL
+            url='ws://127.0.0.1:9944'
         )
 
     def test_query_subscription(self):
@@ -35,6 +36,27 @@ class SubscriptionsTestCase(unittest.TestCase):
             return {'update_nr': update_nr, 'subscription_id': subscription_id}
 
         result = self.substrate.query("System", "Events", [], subscription_handler=subscription_handler)
+
+        self.assertEqual(result['update_nr'], 0)
+        self.assertIsNotNone(result['subscription_id'])
+
+    def test_subscribe_storage_multi(self):
+
+        def subscription_handler(storage_key, updated_obj, update_nr, subscription_id):
+            return {'update_nr': update_nr, 'subscription_id': subscription_id}
+
+        storage_keys = [
+            self.substrate.create_storage_key(
+                "System", "Account", ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"]
+            ),
+            self.substrate.create_storage_key(
+                "System", "Account", ["5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"]
+            )
+        ]
+
+        result = self.substrate.subscribe_storage(
+            storage_keys=storage_keys, subscription_handler=subscription_handler
+        )
 
         self.assertEqual(result['update_nr'], 0)
         self.assertIsNotNone(result['subscription_id'])

--- a/test/test_subscriptions.py
+++ b/test/test_subscriptions.py
@@ -25,8 +25,7 @@ class SubscriptionsTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.substrate = SubstrateInterface(
-            # url=settings.POLKADOT_NODE_URL
-            url='ws://127.0.0.1:9944'
+            url=settings.POLKADOT_NODE_URL
         )
 
     def test_query_subscription(self):


### PR DESCRIPTION
See #327 

Usage example:

```python
def subscription_handler(storage_key, updated_obj, update_nr, subscription_id):
    print(f"Update for {storage_key.params[0]}: {updated_obj.value}")

# Accounts to track
storage_keys = [
    substrate.create_storage_key(
        "System", "Account", ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"]
    ),
    substrate.create_storage_key(
        "System", "Account", ["5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"]
    )
]

result = substrate.subscribe_storage(
    storage_keys=storage_keys, subscription_handler=subscription_handler
)
```