### PR TITLE
Added query_multi() function

### DIFF
--- a/docs/usage/query-storage.md
+++ b/docs/usage/query-storage.md
@@ -49,6 +49,30 @@ print(storage_function.get_param_info())
 # }]
 ```
 
+## Querying multiple storage entries at once
+
+When a large amount of storage entries is requested, the most efficient way is to use the `query_multi()` function. 
+This will batch all the requested storage entries in one RPC request. 
+
+```python
+storage_keys = [
+    substrate.create_storage_key(
+        "System", "Account", ["F4xQKRUagnSGjFqafyhajLs94e7Vvzvr8ebwYJceKpr8R7T"]
+    ),
+    substrate.create_storage_key(
+        "System", "Account", ["GSEX8kR4Kz5UZGhvRUCJG93D5hhTAoVZ5tAe6Zne7V42DSi"]
+    ),
+    substrate.create_storage_key(
+        "Staking", "Bonded", ["GSEX8kR4Kz5UZGhvRUCJG93D5hhTAoVZ5tAe6Zne7V42DSi"]
+    )
+]
+
+result = substrate.query_multi(storage_keys)
+
+for storage_key, value_obj in result:
+    print(storage_key, value_obj)
+```
+
 ## Query a mapped storage function
 Mapped storage functions can be iterated over all key/value pairs, for these type of storage functions `query_map()` 
 can be used.

--- a/examples/storage_subscription.py
+++ b/examples/storage_subscription.py
@@ -17,7 +17,7 @@ from substrateinterface import SubstrateInterface
 
 
 def subscription_handler(storage_key, updated_obj, update_nr, subscription_id):
-    print(f"Update for {storage_key.params[0]}: {updated_obj.value}")
+    print(f"Update for {storage_key}: {updated_obj.value}")
 
 
 substrate = SubstrateInterface(url="ws://127.0.0.1:9944")
@@ -29,7 +29,10 @@ storage_keys = [
     ),
     substrate.create_storage_key(
         "System", "Account", ["5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"]
-    )
+    ),
+    substrate.create_storage_key(
+        "System", "Events"
+    ),
 ]
 
 result = substrate.subscribe_storage(

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -122,6 +122,34 @@ class QueryTestCase(unittest.TestCase):
         result = self.kusama_substrate.query("System", "PalletVersion")
         self.assertGreaterEqual(result.value, 0)
 
+    def test_query_multi(self):
+
+        storage_keys = [
+            self.kusama_substrate.create_storage_key(
+                "System", "Account", ["F4xQKRUagnSGjFqafyhajLs94e7Vvzvr8ebwYJceKpr8R7T"]
+            ),
+            self.kusama_substrate.create_storage_key(
+                "System", "Account", ["GSEX8kR4Kz5UZGhvRUCJG93D5hhTAoVZ5tAe6Zne7V42DSi"]
+            ),
+            self.kusama_substrate.create_storage_key(
+                "Staking", "Bonded", ["GSEX8kR4Kz5UZGhvRUCJG93D5hhTAoVZ5tAe6Zne7V42DSi"]
+            )
+        ]
+
+        result = self.kusama_substrate.query_multi(storage_keys)
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0][0].params[0], "F4xQKRUagnSGjFqafyhajLs94e7Vvzvr8ebwYJceKpr8R7T")
+        self.assertGreater(result[0][1].value['nonce'], 0)
+        self.assertEqual(result[1][1].value['nonce'], 0)
+
+    def test_storage_key_unknown(self):
+        with self.assertRaises(StorageFunctionNotFound):
+            self.kusama_substrate.create_storage_key("Unknown", "Unknown")
+
+        with self.assertRaises(StorageFunctionNotFound):
+            self.kusama_substrate.create_storage_key("System", "Unknown")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Example:

```python
storage_keys = [
    substrate.create_storage_key(
        "System", "Account", ["F4xQKRUagnSGjFqafyhajLs94e7Vvzvr8ebwYJceKpr8R7T"]
    ),
    substrate.create_storage_key(
        "System", "Account", ["GSEX8kR4Kz5UZGhvRUCJG93D5hhTAoVZ5tAe6Zne7V42DSi"]
    ),
    substrate.create_storage_key(
        "Staking", "Bonded", ["GSEX8kR4Kz5UZGhvRUCJG93D5hhTAoVZ5tAe6Zne7V42DSi"]
    )
]

result = substrate.query_multi(storage_keys)

for storage_key, value_obj in result:
    print(storage_key, value_obj)
``` 