### PR TITLE
Add support for runtime calls at other blocks than the most recent.

### DIFF
--- a/substrateinterface/base.py
+++ b/substrateinterface/base.py
@@ -1202,7 +1202,7 @@ class SubstrateInterface:
 
         return extrinsics
 
-    def runtime_call(self, api: str, method: str, params: Union[list, dict] = None) -> ScaleType:
+    def runtime_call(self, api: str, method: str, params: Union[list, dict] = None, block_hash: str = None) -> ScaleType:
         """
         Calls a runtime API method
 
@@ -1211,6 +1211,7 @@ class SubstrateInterface:
         api: Name of the runtime API e.g. 'TransactionPaymentApi'
         method: Name of the method e.g. 'query_fee_details'
         params: List of parameters needed to call the runtime API
+        block_hash: Hash of the block at which to make the runtime API call
 
         Returns
         -------
@@ -1251,7 +1252,7 @@ class SubstrateInterface:
                 param_data += scale_obj.encode(params[param['name']])
 
         # RPC request
-        result_data = self.rpc_request("state_call", [f'{api}_{method}', str(param_data)])
+        result_data = self.rpc_request("state_call", [f'{api}_{method}', str(param_data), block_hash])
 
         # Decode result
         result_obj = self.runtime_config.create_scale_object(runtime_call_def['type'])

--- a/substrateinterface/contracts.py
+++ b/substrateinterface/contracts.py
@@ -741,7 +741,7 @@ class ContractInstance:
         return cls(contract_address=contract_address, metadata=metadata, substrate=substrate)
 
     def read(self, keypair: Keypair, method: str, args: dict = None,
-             value: int = 0, gas_limit: int = None) -> GenericContractExecResult:
+             value: int = 0, gas_limit: int = None, block_hash: str = None) -> GenericContractExecResult:
         """
         Used to execute non-mutable messages to for example read data from the contract using getters. Can also be used
         to predict gas limits and 'dry-run' the execution when a mutable message is used.
@@ -754,6 +754,7 @@ class ContractInstance:
         args: arguments of message in {'name': value} format
         value: value to send when executing the message
         gas_limit: dict repesentation of `WeightV2` type
+        block_hash: hash of the block to execute the message on
 
         Returns
         -------
@@ -770,7 +771,7 @@ class ContractInstance:
             'origin': keypair.ss58_address,
             'value': value,
             'storage_deposit_limit': None
-        })
+        }, block_hash)
         if 'Error' in call_result['result']:
             raise ContractReadFailedException(call_result.value['result']['Error'])
 

--- a/test/test_contracts.py
+++ b/test/test_contracts.py
@@ -393,6 +393,12 @@ class FlipperInstanceTestCase(unittest.TestCase):
 
         self.assertEqual(False, result.contract_result_data.value)
 
+    def test_instance_read_at_not_best_block(self):
+        parent_hash = self.substrate.get_block_header()['header']['parentHash']
+        result = self.contract.read(self.keypair, 'get', block_hash = parent_hash)
+
+        self.assertEqual(False, result.contract_result_data.value)
+
 
 class FlipperInstanceV4TestCase(FlipperInstanceTestCase):
     def setUp(self) -> None:

--- a/test/test_runtime_call.py
+++ b/test/test_runtime_call.py
@@ -41,6 +41,13 @@ class RuntimeCallTestCase(unittest.TestCase):
         self.assertGreater(result.value['spec_version'], 0)
         self.assertEqual('polkadot', result.value['spec_name'])
 
+    def test_core_version_at_not_best_block(self):
+        parent_hash = self.substrate.get_block_header()['header']['parentHash']
+        result = self.substrate.runtime_call("Core", "version", block_hash = parent_hash)
+
+        self.assertGreater(result.value['spec_version'], 0)
+        self.assertEqual('polkadot', result.value['spec_name'])
+
     def test_transaction_payment(self):
         call = self.substrate.compose_call(
             call_module='Balances',


### PR DESCRIPTION
It's often useful to `read` contracts at old blocks. For this it's necessary to be able to make runtime calls at old blocks. The appropriate RPC call in substrate supports this option -- this PR is adding the support here. 

I'm sorry if I missed something, like bumping version, running linter or things like that, but I wasn't sure how to do these things.