### PR TITLE
Added multiple params as key support for query_map

### DIFF
--- a/test/test_query_map.py
+++ b/test/test_query_map.py
@@ -213,13 +213,15 @@ class QueryMapTestCase(unittest.TestCase):
         )
         self.assertEqual(era_stakers.records, [])
 
-    def test_double_map_missing_param(self):
-        with self.assertRaises(ValueError) as cm:
-            self.kusama_substrate.query_map(
-                module='Staking',
-                storage_function='ErasStakers'
-            )
-        self.assertEqual('Storage function map requires 1 parameters, 0 given', str(cm.exception))
+    def test_nested_keys(self):
+
+        result = self.kusama_substrate.query_map(
+            module='ConvictionVoting',
+            storage_function='VotingFor',
+            max_results=10
+        )
+        self.assertTrue(self.kusama_substrate.is_valid_ss58_address(result[0][0][0].value))
+        self.assertGreaterEqual(result[0][0][1], 0)
 
     def test_double_map_too_many_params(self):
         with self.assertRaises(ValueError) as cm:
@@ -228,7 +230,7 @@ class QueryMapTestCase(unittest.TestCase):
                 storage_function='ErasStakers',
                 params=[21000000, 2]
             )
-        self.assertEqual('Storage function map requires 1 parameters, 2 given', str(cm.exception))
+        self.assertEqual('Storage function map can accept max 1 parameters, 2 given', str(cm.exception))
 
     def test_map_with_param(self):
         with self.assertRaises(ValueError) as cm:
@@ -237,7 +239,7 @@ class QueryMapTestCase(unittest.TestCase):
                 storage_function='Account',
                 params=[2]
             )
-        self.assertEqual('Storage function map requires 0 parameters, 1 given', str(cm.exception))
+        self.assertEqual('Storage function map can accept max 0 parameters, 1 given', str(cm.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Possibility to omit multiple parameters when using `query_map`, which was bound to only the last parameter. 

For example:

```python
result = self.kusama_substrate.query_map(
            module='ConvictionVoting',
            storage_function='VotingFor',
            max_results=10
        )
print([record for record in result])

# [[(<scale_info::0(value=Cwvu9hqzqCMMK8yLVAcSKPjMDs2yQrrfEpAV3ZVJqpQz7RJ)>, <U16(value=0)>), <scale_info::600(value={'Casting': {'votes': [(72, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}}), (86, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}}), (122, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}})], 'delegations': {'votes': 58500000000000000, 'capital': 58500000000000000}, 'prior': (0, 0)}})>], [(<scale_info::0(value=Cwvu9hqzqCMMK8yLVAcSKPjMDs2yQrrfEpAV3ZVJqpQz7RJ)>, <U16(value=14)>), <scale_info::600(value={'Casting': {'votes': [], 'delegations': {'votes': 57000000000000000, 'capital': 57000000000000000}, 'prior': (0, 0)}})>], [(<scale_info::0(value=Cwvu9hqzqCMMK8yLVAcSKPjMDs2yQrrfEpAV3ZVJqpQz7RJ)>, <U16(value=15)>), <scale_info::600(value={'Casting': {'votes': [(39, {'Standard': {'vote': {'aye': True, 'conviction': 'None'}, 'balance': 50000000000}}), (80, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}}), (91, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}}), (96, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}})], 'delegations': {'votes': 57000000000000000, 'capital': 57000000000000000}, 'prior': (0, 0)}})>], [(<scale_info::0(value=Cwvu9hqzqCMMK8yLVAcSKPjMDs2yQrrfEpAV3ZVJqpQz7RJ)>, <U16(value=10)>), <scale_info::600(value={'Casting': {'votes': [(16, {'Standard': {'vote': {'aye': True, 'conviction': 'None'}, 'balance': 50000000000}})], 'delegations': {'votes': 57000000000000000, 'capital': 57000000000000000}, 'prior': (0, 0)}})>], [(<scale_info::0(value=Cwvu9hqzqCMMK8yLVAcSKPjMDs2yQrrfEpAV3ZVJqpQz7RJ)>, <U16(value=1)>), <scale_info::600(value={'Casting': {'votes': [(8, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}}), (14, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}}), (17, {'Standard': {'vote': {'aye': True, 'conviction': 'None'}, 'balance': 50000000000}}), (23, {'Standard': {'vote': {'aye': True, 'conviction': 'None'}, 'balance': 50000000000}}), (24, {'Standard': {'vote': {'aye': True, 'conviction': 'None'}, 'balance': 50000000000}}), (34, {'Standard': {'vote': {'aye': True, 'conviction': 'None'}, 'balance': 50000000000}}), (42, {'Standard': {'vote': {'aye': True, 'conviction': 'None'}, 'balance': 50000000000}}), (43, {'Standard': {'vote': {'aye': True, 'conviction': 'None'}, 'balance': 50000000000}}), (49, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}}), (53, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}}), (85, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}}), (118, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}}), (130, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}}), (167, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}}), (219, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}}), (230, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}}), (232, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}})], 'delegations': {'votes': 57000000000000000, 'capital': 57000000000000000}, 'prior': (0, 0)}})>], [(<scale_info::0(value=Cwvu9hqzqCMMK8yLVAcSKPjMDs2yQrrfEpAV3ZVJqpQz7RJ)>, <U16(value=20)>), <scale_info::600(value={'Casting': {'votes': [(15, {'Standard': {'vote': {'aye': True, 'conviction': 'None'}, 'balance': 50000000000}}), (89, {'Standard': {'vote': {'aye': True, 'conviction': 'Locked1x'}, 'balance': 50000000000}})], 'delegations': {'votes': 57000000000000000, 'capital': 57000000000000000}, 'prior': (0, 0)}})>], [(<scale_info::0(value=Dcu6mYmwZjGkYJt43BJvuWnxGUZfsDZUos3xL4hKYMRWaT7)>, <U16(value=0)>), <scale_info::600(value={'Delegating': {'balance': 100000000000, 'target': 'Day71GSJAxUUiFic8bVaWoAczR3Ue3jNonBZthVHp2BKzyJ', 'conviction': 'None', 'delegations': {'votes': 0, 'capital': 0}, 'prior': (16871527, 113000000000)}})>], [(<scale_info::0(value=Dcu6mYmwZjGkYJt43BJvuWnxGUZfsDZUos3xL4hKYMRWaT7)>, <U16(value=14)>), <scale_info::600(value={'Delegating': {'balance': 100000000000, 'target': 'Day71GSJAxUUiFic8bVaWoAczR3Ue3jNonBZthVHp2BKzyJ', 'conviction': 'None', 'delegations': {'votes': 0, 'capital': 0}, 'prior': (16871527, 113000000000)}})>], [(<scale_info::0(value=Dcu6mYmwZjGkYJt43BJvuWnxGUZfsDZUos3xL4hKYMRWaT7)>, <U16(value=31)>), <scale_info::600(value={'Delegating': {'balance': 100000000000, 'target': 'Day71GSJAxUUiFic8bVaWoAczR3Ue3jNonBZthVHp2BKzyJ', 'conviction': 'None', 'delegations': {'votes': 0, 'capital': 0}, 'prior': (16871527, 113000000000)}})>], [(<scale_info::0(value=Dcu6mYmwZjGkYJt43BJvuWnxGUZfsDZUos3xL4hKYMRWaT7)>, <U16(value=21)>), <scale_info::600(value={'Delegating': {'balance': 100000000000, 'target': 'Day71GSJAxUUiFic8bVaWoAczR3Ue3jNonBZthVHp2BKzyJ', 'conviction': 'None', 'delegations': {'votes': 0, 'capital': 0}, 'prior': (16871527, 113000000000)}})>]]
```

Closes #350 