### PR TITLE
(fix) mpz has no attribute to_bytes py311

### DIFF
--- a/substrateinterface/utils/ecdsa_helpers.py
+++ b/substrateinterface/utils/ecdsa_helpers.py
@@ -35,13 +35,13 @@ class PublicKey:
         self.point = int.from_bytes(private_key, byteorder='big') * BIP32_CURVE.generator
 
     def __bytes__(self):
-        xstr = self.point.x().to_bytes(32, byteorder='big')
-        parity = self.point.y() & 1
+        xstr = int(self.point.x()).to_bytes(32, byteorder='big')
+        parity = int(self.point.y()) & 1
         return (2 + parity).to_bytes(1, byteorder='big') + xstr
 
     def address(self):
-        x = self.point.x()
-        y = self.point.y()
+        x = int(self.point.x())
+        y = int(self.point.y())
         s = x.to_bytes(32, 'big') + y.to_bytes(32, 'big')
         return to_checksum_address(eth_utils_keccak(s)[12:])
 
@@ -72,7 +72,7 @@ def derive_bip32childkey(parent_key, parent_chain_code, i):
         key, chain_code = h[:32], h[32:]
         a = int.from_bytes(key, byteorder='big')
         b = int.from_bytes(parent_key, byteorder='big')
-        key = (a + b) % BIP32_CURVE.order
+        key = (a + b) % int(BIP32_CURVE.order)
         if a < BIP32_CURVE.order and key != 0:
             key = key.to_bytes(32, byteorder='big')
             break


### PR DESCRIPTION
When running `test_keypais.py`, I get:
```
FAILED test/test_keypair.py::KeyPairTestCase::test_create_ecdsa_keypair_mnemonic - AttributeError: 'mpz' object has no attribute 'to_bytes'
FAILED test/test_keypair.py::KeyPairTestCase::test_create_ecdsa_keypair_uri - AttributeError: 'mpz' object has no attribute 'to_bytes'
FAILED test/test_keypair.py::KeyPairTestCase::test_sign_and_verify_ecdsa - AttributeError: 'mpz' object has no attribute 'to_bytes'
FAILED test/test_keypair.py::KeyPairTestCase::test_sign_and_verify_invalid_signature_ecdsa - AttributeError: 'mpz' object has no attribute 'to_bytes'
FAILED test/test_keypair.py::KeyPairTestCase::test_sign_and_verify_public_ethereum_address - AttributeError: 'mpz' object has no attribute 'to_bytes'
```

It seems to be due to `BIP32_CURVE.order()` not being an `int`. It is also an issue with the x() and y() returns