### PR TITLE
Determine correct ContractExecResult by PalletVersion

### DIFF
--- a/substrateinterface/base.py
+++ b/substrateinterface/base.py
@@ -797,7 +797,7 @@ class SubstrateInterface:
 
         # Generate storage key prefix
         storage_key = StorageKey.create_from_storage_function(
-            module, storage_function, params, runtime_config=self.runtime_config, metadata=self.metadata
+            module, storage_item.value['name'], params, runtime_config=self.runtime_config, metadata=self.metadata
         )
         prefix = storage_key.to_hex()
 
@@ -1021,7 +1021,7 @@ class SubstrateInterface:
         else:
 
             storage_key = StorageKey.create_from_storage_function(
-                module, storage_function, params, runtime_config=self.runtime_config, metadata=self.metadata
+                module, storage_item.value['name'], params, runtime_config=self.runtime_config, metadata=self.metadata
             )
 
         if callable(subscription_handler):

--- a/substrateinterface/contracts.py
+++ b/substrateinterface/contracts.py
@@ -718,6 +718,17 @@ class ContractInstance:
         self.contract_address = contract_address
         self.metadata = metadata
 
+        self.init()
+
+    def init(self):
+        # Determine ContractExecResult according to PalletVersion
+        pallet_version = self.substrate.query("Contracts", "PalletVersion")
+
+        if pallet_version.value <= 9:
+            self.substrate.runtime_config.update_type_registry_types({"ContractExecResult": "ContractExecResultTo267"})
+        else:
+            self.substrate.runtime_config.update_type_registry_types({"ContractExecResult": "ContractExecResultTo269"})
+
     @classmethod
     def create_from_address(cls, contract_address: str, metadata_file: str,
                             substrate: SubstrateInterface = None) -> "ContractInstance":

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -116,11 +116,11 @@ class QueryTestCase(unittest.TestCase):
 
     def test_well_known_pallet_version(self):
 
-        sf = self.kusama_substrate.get_metadata_storage_function("System", "PalletVersion")
+        sf = self.kusama_substrate.get_metadata_storage_function("Balances", "PalletVersion")
         self.assertEqual(sf.value['name'], ':__STORAGE_VERSION__:')
 
-        result = self.kusama_substrate.query("System", "PalletVersion")
-        self.assertGreaterEqual(result.value, 0)
+        result = self.kusama_substrate.query("Balances", "PalletVersion")
+        self.assertGreaterEqual(result.value, 1)
 
     def test_query_multi(self):
 


### PR DESCRIPTION
* Fixed generate PalletVersion storage key
* Determine correct `ContractExecResult` by PalletVersion

Fixes #368 