### PR TITLE
Increase max version allowed for eth-utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ xxhash>=1.3.0,<4
 pytest>=4.4.0
 ecdsa>=0.17.0,<1
 eth-keys>=0.2.1,<1
-eth_utils>=1.3.0,<3
+eth_utils>=1.3.0,<5
 pycryptodome>=3.11.0,<4
 PyNaCl>=1.0.1,<2
 


### PR DESCRIPTION
The latest version is 4.1.1 and there isn't any change that doesn't work with the library