### PR TITLE
CheckMetadataHash signed extension support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ eth_utils>=1.3.0,<5
 pycryptodome>=3.11.0,<4
 PyNaCl>=1.0.1,<2
 
-scalecodec>=1.2.8,<1.3
+scalecodec>=1.2.10,<1.3
 py-sr25519-bindings>=0.2.0,<1
 py-ed25519-zebra-bindings>=1.0,<2
 py-bip39-bindings>=0.1.9,<1

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ setup(
         'eth_utils>=1.3.0,<3',
         'pycryptodome>=3.11.0,<4',
         'PyNaCl>=1.0.1,<2',
-        'scalecodec>=1.2.8,<1.3',
+        'scalecodec>=1.2.10,<1.3',
         'py-sr25519-bindings>=0.2.0,<1',
         'py-ed25519-zebra-bindings>=1.0,<2',
         'py-bip39-bindings>=0.1.9,<1'

--- a/substrateinterface/base.py
+++ b/substrateinterface/base.py
@@ -1490,6 +1490,11 @@ class SubstrateInterface:
                     ['asset_id', signed_extensions['ChargeAssetTxPayment']['extrinsic']]
                 )
 
+            if 'CheckMetadataHash' in signed_extensions:
+                signature_payload.type_mapping.append(
+                    ['mode', signed_extensions['CheckMetadataHash']['extrinsic']]
+                )
+
             if 'CheckSpecVersion' in signed_extensions:
                 signature_payload.type_mapping.append(
                     ['spec_version', signed_extensions['CheckSpecVersion']['additional_signed']]
@@ -1515,6 +1520,11 @@ class SubstrateInterface:
                     ['block_hash', signed_extensions['CheckEra']['additional_signed']]
                 )
 
+            if 'CheckMetadataHash' in signed_extensions:
+                signature_payload.type_mapping.append(
+                    ['metadata_hash', signed_extensions['CheckMetadataHash']['additional_signed']]
+                )
+
         if include_call_length:
 
             length_obj = self.runtime_config.create_scale_object('Bytes')
@@ -1532,7 +1542,9 @@ class SubstrateInterface:
             'genesis_hash': genesis_hash,
             'block_hash': block_hash,
             'transaction_version': self.transaction_version,
-            'asset_id': {'tip': tip, 'asset_id': tip_asset_id}
+            'asset_id': {'tip': tip, 'asset_id': tip_asset_id},
+            'metadata_hash': None,
+            'mode': 'Disabled'
         }
 
         signature_payload.encode(payload_dict)
@@ -1624,7 +1636,8 @@ class SubstrateInterface:
             'nonce': nonce,
             'era': era,
             'tip': tip,
-            'asset_id': {'tip': tip, 'asset_id': tip_asset_id}
+            'asset_id': {'tip': tip, 'asset_id': tip_asset_id},
+            'mode': 'Disabled'
         }
 
         # Check if ExtrinsicSignature is MultiSignature, otherwise omit signature_version

--- a/test/test_create_extrinsics.py
+++ b/test/test_create_extrinsics.py
@@ -192,7 +192,7 @@ class CreateExtrinsicsTestCase(unittest.TestCase):
             call_module='System',
             call_function='remark',
             call_params={
-                'remark': '0x' + ('01' * 177)
+                'remark': '0x' + ('01' * 175)
             }
         )
 
@@ -206,7 +206,7 @@ class CreateExtrinsicsTestCase(unittest.TestCase):
             call_module='System',
             call_function='remark',
             call_params={
-                'remark': '0x' + ('01' * 178)
+                'remark': '0x' + ('01' * 176)
             }
         )
 


### PR DESCRIPTION
The `CheckMetadataHash` signed extension enables the new metadata hash verification feature that was approved as
[RFC78](https://polkadot-fellows.github.io/RFCs/approved/0078-merkleized-metadata.html).

See https://github.com/polkadot-fellows/runtimes/pull/337

This PR only allow mode is `Disabled` for now, but ensures compatibility with upcoming Kusama/Polkadot release.