### PR TITLE
Update version of eth-utils to match requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ setup(
         'xxhash>=1.3.0,<4',
         'ecdsa>=0.17.0,<1',
         'eth-keys>=0.2.1,<1',
-        'eth_utils>=1.3.0,<3',
+        'eth_utils>=1.3.0,<5',
         'pycryptodome>=3.11.0,<4',
         'PyNaCl>=1.0.1,<2',
         'scalecodec>=1.2.10,<1.3',


### PR DESCRIPTION
In #388 I edited the requirements.txt and didn't notice that the requirements are hardcoded in the setup.py. This PR is to have the same version in both

https://github.com/polkascan/py-substrate-interface/blob/43ad00cca215dfafd4607be6440aecd198ee6089/requirements.txt#L10

Would you consider using `pyproject.toml` instead of setup.py to avoid this errors? Also setup.py is being deprecated afaik. 

