### PR TITLE
Bump eht-utils to allow version 5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ xxhash>=1.3.0,<4
 pytest>=4.4.0
 ecdsa>=0.17.0,<1
 eth-keys>=0.2.1,<1
-eth_utils>=1.3.0,<5
+eth_utils>=1.3.0,<6
 pycryptodome>=3.11.0,<4
 PyNaCl>=1.0.1,<2
 

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ setup(
         'xxhash>=1.3.0,<4',
         'ecdsa>=0.17.0,<1',
         'eth-keys>=0.2.1,<1',
-        'eth_utils>=1.3.0,<5',
+        'eth_utils>=1.3.0,<6',
         'pycryptodome>=3.11.0,<4',
         'PyNaCl>=1.0.1,<2',
         'scalecodec>=1.2.10,<1.3',


### PR DESCRIPTION
web3.py requires in the new version 7 to have eth-utils version 5. To make them both compatible I increase the allowed version here