### PR TITLE
Fix SyntaxError in submit_extrinsic error path (unmatched f-string quotes)

### DIFF
--- a/substrateinterface/base.py
+++ b/substrateinterface/base.py
@@ -1727,7 +1727,7 @@ class SubstrateInterface:
                         'finalized': False
                     }
             elif message['params']['result'] in ['dropped']:
-                raise ValueError(f'Submit extrinsic failed: {message['params']['result']}')
+                raise ValueError(f"Submit extrinsic failed: {message['params']['result']}")
 
         if wait_for_inclusion or wait_for_finalization:
             response = self.rpc_request(


### PR DESCRIPTION
This fixes a SyntaxError introduced in substrateinterface/base.py that prevents the package from importing on Python 3.11+.

**What broke**

In SubstrateInterface.submit_extrinsic(), the "dropped" error branch raised:

`raise ValueError(f'Submit extrinsic failed: {message['params']['result']}')`

Because the outer f-string uses single quotes and the expression contains single quotes (message['params']...), Python raises:

`SyntaxError: f-string: unmatched '['`