### PR TITLE
Fix unscoped `logging.debug` in rpc_request

### DIFF
--- a/substrateinterface/base.py
+++ b/substrateinterface/base.py
@@ -274,7 +274,7 @@ class SubstrateInterface:
         }
 
         self.debug_message('RPC request #{}: "{}"'.format(request_id, method))
-        logging.debug(payload)
+        self.debug_message(payload)
         return self.transport.rpc_request(payload, result_handler=result_handler)
 
     @property


### PR DESCRIPTION
Very simple fix. This `logging.debug` was logging to the root logger and was hard to turn off. Changed it to use the existing `self.debug_message` facility.